### PR TITLE
force project to use local ng module

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,12 +3,12 @@
   "version": "0.0.0",
   "license": "MIT",
   "scripts": {
-    "ng": "ng",
-    "start": "ng serve",
-    "build": "ng build",
-    "test": "ng test",
-    "lint": "ng lint",
-    "e2e": "ng e2e"
+    "ng": "$(npm bin)/ng",
+    "start": "$(npm bin)/ng serve",
+    "build": "$(npm bin)/ng build",
+    "test": "$(npm bin)/ng test",
+    "lint": "$(npm bin)/ng lint",
+    "e2e": "$(npm bin)/ng e2e"
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
this will make the npm use ng in the node_module/. If you are using nvm and switching versions you have to install ng on each version. 